### PR TITLE
Update MainView.js routes Render props callback

### DIFF
--- a/src/views/MainView.js
+++ b/src/views/MainView.js
@@ -32,26 +32,29 @@ const MainView = ({ model }) => {
 
         <Switch>
 
-          <Route exact path="/" render={() => (
-
+          <Route exact path="/" render={(props) => (
+    
             <HomePage 
+              {...props}    
               backgroundImage={get(homePage, "fields.backgroundImage", {})}
             />
 
           )} />
 
-          <Route exact path="/press" render={() => (
+          <Route exact path="/press" render={(props) => (
 
             <Press 
+              {...props}                        
               backgroundImage={get(homePage, "fields.backgroundImage", {})}
               articles={pressPieces}
             />
 
           )} />
 
-          <Route exact path="/tour" render={() => (
+          <Route exact path="/tour" render={(props) => (
 
             <Live
+              {...props}
               backgroundImage={get(homePage, "fields.backgroundImage", {})}
               shows={shows}
             />


### PR DESCRIPTION
pass render prop's callback function's `props` from argument to component being returned from render prop callback function. Spreading the properties from the `props` argument will give you access to the route props (match, location and history) from within the rendered component (component being returned from render prop callback function)